### PR TITLE
Make deployment environment agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ The system will watch files and execute tasks whenever one of them changes.
 The site will automatically refresh since it is bundled with livereload.
 
 # Deployment
+Set the AWS environment variables:
+```
+export AWS_ACCOUNT_ID=$(aws sts get-caller-identity | jq .Account -r)
+export AWS_REGION=$(aws configure get region)
+```
 To prepare the app for deployment run:
 
 ```

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -15,7 +15,7 @@ new CdkStack(app, 'CdkStack', {
 
   /* Uncomment the next line if you know exactly what Account and Region you
    * want to deploy the stack to. */
-  // env: { region: 'us-west-2' },
+  env: { region: process.env.AWS_REGION },
 
   /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
 });

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -15,7 +15,7 @@ new CdkStack(app, 'CdkStack', {
 
   /* Uncomment the next line if you know exactly what Account and Region you
    * want to deploy the stack to. */
-  env: { region: 'us-west-2' },
+  // env: { region: 'us-west-2' },
 
   /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
 });


### PR DESCRIPTION
Removes hardcoded AWS environment region to allow for deployment to any AWS account/region
Updates README to include setting of the AWS environment variables