### PR TITLE
fix: fix merge problem in index.js. use earthdata-dashboard as stack prefix instead of CdkStack

### DIFF
--- a/app/assets/scripts/components/home/index.js
+++ b/app/assets/scripts/components/home/index.js
@@ -484,15 +484,7 @@ class Home extends React.Component {
                   <IntroWelcomeTitle>Welcome</IntroWelcomeTitle>
                   <Prose>
                     <p>
-<<<<<<< HEAD
-                    The Multi-Mission Algorithm and Analysis Platform (MAAP) is a collaborative science platform for biomass research. 
-                    The platform is a collaboration between science and engineering teams at NASA and ESA. 
-                    This experimental dashboard enables exploration of the data made available, and sharing of results developed by science users in the platform.
-=======
-                    As communities around the world have changed their behavior in response
-                    to the spread of global phenomena, NASA satellites have observed changes in the
-                    environment. <Link to='/about' title='Read more on the about page'>Read more...</Link>
->>>>>>> f42847c908e76a4354d37c559b2d99b17738d176
+                      Project description goes here.
                     </p>
                   </Prose>
                 </IntroWelcome>

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -4,7 +4,7 @@ import * as cdk from '@aws-cdk/core';
 import { CdkStack } from '../lib/cdk-stack';
 
 const app = new cdk.App();
-new CdkStack(app, `CdkStack-${process.env.PROJECT}-${process.env.STAGE}`, {
+new CdkStack(app, `earthdata-dashboard-${process.env.PROJECT}-${process.env.STAGE}`, {
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
    * but a single synthesized template can be deployed anywhere. */


### PR DESCRIPTION
Fixes #4 and #5

1. There was a merge problem with index.js that included a `HEAD >>>` diff, the prevented it from transpiling and deploying.
2. The CloudFormation Stack was previously prefixed with CdkStack, now it's prefixed with earthdata-dashboard.